### PR TITLE
[bugfix] Fix null image source error in ios

### DIFF
--- a/src/components/GameThumbNail.js
+++ b/src/components/GameThumbNail.js
@@ -8,7 +8,8 @@ export default class GameThumbNail extends React.Component {
     super(props);
     this.state = {
       gid: this.props.gid,
-      url: null,
+      /* question mark image url is used temporarily */
+      url: 'https://imgur.com/a/Qw6mZkb',
       size: this.props.size,
       radius: this.props.size / 2,
     };


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
- None
## Details
<!-- Detailed description of the change/feature -->
- ios에서 image 컴포넌트의 source property의 url값이 null이면 runtime error가
터지는 부분 파악 (https://github.com/facebook/react-native/issues/11140 참고)
  - GameThumbNail의 default url state값을 null이 아닌 question mark 이미지로
 수정
