### PR TITLE
Taehyun dev

### DIFF
--- a/src/screens/GroupListScreen.js
+++ b/src/screens/GroupListScreen.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { FlatList, View } from 'react-native';
 
@@ -8,6 +8,7 @@ import GroupListEntry from '~/components/GroupListEntry';
 import GroupListEntryPopup from '~/components/GroupListEntryPopup';
 
 import image from '~/utils/image_sample';
+import { getGroupInfo } from '~/api/boardgamegeek';
 
 const SampleList = [
   {
@@ -27,6 +28,12 @@ const SampleList = [
 ];
 
 function GroupListScreen(props) {
+  console.log('GroupListScreen is called');
+
+  useEffect(() => {
+    getGroupInfo(1, props.getGroup);
+  }, []);
+
   let data = props.groupList;
   if (!data) data = SampleList;
 
@@ -73,4 +80,11 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, null)(GroupListScreen);
+function mapDispatchToProps(dispatch) {
+  return {
+    getGroup: (groupList) =>
+      dispatch({ type: 'GET_GROUP', payload: { groupList } }),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(GroupListScreen);

--- a/src/screens/GroupListScreen.js
+++ b/src/screens/GroupListScreen.js
@@ -58,6 +58,7 @@ function GroupListScreen(props) {
             }}
           />
         )}
+        keyExtractor={(item, index) => index.toString()}
       />
       <FloatingButton
         onPress={() => {

--- a/src/screens/GroupScreen.js
+++ b/src/screens/GroupScreen.js
@@ -8,7 +8,6 @@ import styled from 'styled-components';
 import GroupRegisterScreen from './GroupRegisterScreen';
 
 import GroupListScreen from './GroupListScreen';
-import { getGroupInfo } from '~/api/boardgamegeek';
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -45,9 +44,6 @@ function GroupScreen(props) {
     place: 'test3',
   };
 
-  console.log(`GroupScreen Start`);
-  getGroupInfo(1, props.getGroup);
-  console.log(`GroupScreen End`);
   return (
     <Stack.Navigator>
       <Stack.Screen name="Group List" component={GroupListScreen} />
@@ -56,11 +52,4 @@ function GroupScreen(props) {
   );
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    getGroup: (groupList) =>
-      dispatch({ type: 'GET_GROUP', payload: { groupList } }),
-  };
-}
-
-export default connect(null, mapDispatchToProps)(GroupScreen);
+export default GroupScreen;

--- a/src/screens/GroupScreen.js
+++ b/src/screens/GroupScreen.js
@@ -16,34 +16,6 @@ const Container = styled.SafeAreaView`
 const Stack = createStackNavigator();
 
 function GroupScreen(props) {
-  //let getGroup = props.getGroup;
-  //fetch(
-  //'http://ec2-13-125-12-178.ap-northeast-2.compute.amazonaws.com:8080/users/1/groups',
-  //{
-  //method: 'GET',
-  //headers: { 'content-type': 'application/json' },
-  //}
-  //)
-  //.then((res) => {
-  //console.log('Get group list from server!!');
-  //return res.json();
-  //})
-  //.then((res) => {
-  //console.log('res.items: ', res.items);
-  //console.log(props);
-  //// res.items로 넣을 경우 무한 로딩
-  //getGroup(res.items);
-  //})
-  //.catch((err) => {
-  //console.error(err);
-  //});
-  const test = {
-    image: 'exam1',
-    name: 'exam2',
-    members: ['b'],
-    place: 'test3',
-  };
-
   return (
     <Stack.Navigator>
       <Stack.Screen name="Group List" component={GroupListScreen} />


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
- None
## Details
<!-- Detailed description of the change/feature -->
- 그룹 리스트 서버 데이터 fetch 로직 수정 (using useEffect) 
  - GroupScreen에서 서버 정보를 가져오고, getGroup action dispatch후, group.groupList 상태 구독을 한 GroupListScreen이 re-render하는 로직을 useEffect를 이용해 GroupScreen did-mount 시점에 서버로부터 group list정보를 가져오고 getGroup action dispatch하고 re-render하는 로직으로 수정
- FlatList에 keyExtractor prop 추가